### PR TITLE
Remove ref to deprecated fn `org-babel-get-header`

### DIFF
--- a/ob-nim.el
+++ b/ob-nim.el
@@ -120,12 +120,8 @@ header arguments."
 (defun org-babel-nim-expand-nim (body params)
   "Expand a block of nim code with org-babel according to
 its header arguments."
-  (let* ((vars (if (fboundp 'org-babel--get-vars)
-                   (org-babel--get-vars params)
-                 (mapcar #'cdr (org-babel-get-header params :var))))
-         (colnames (if (fboundp 'org-babel--get-vars)
-                       (cdr (assq :colname-names params))
-                     (cdar (org-babel-get-header params :colname-names))))
+  (let* ((vars (org-babel--get-vars params))
+         (colnames (cdr (assq :colname-names params)))
          (imports (org-babel-read
                    (or (cdr (assoc :import params))
                        (org-entry-get nil "import" t))


### PR DESCRIPTION
`org-babel-get-header` got removed from Org code roughly 5 years back: https://code.orgmode.org/bzg/org-mode/commit/e69e18dd71bdf0c9bae9546bf026a1123b9a8c53

Before this commit, we get this warning each time ob-nim.el is compiled:

```
In end of data:
ob-nim.el:128:29: Warning: the function ‘org-babel-get-header’ is not known to
    be defined.
```

After this commit, this warning goes away.