### PR TITLE
Revert "Do not try to convert results to numbers"

### DIFF
--- a/ob-nim.el
+++ b/ob-nim.el
@@ -111,11 +111,16 @@ header arguments."
 	        "")))
       (when results
 	    (org-babel-reassemble-table
-	     results
+	     (org-babel-result-cond (cdr (assoc :result-params params))
+	       (org-babel-read results t)
+	       (let ((tmp-file (org-babel-temp-file "c-")))
+	         (with-temp-file tmp-file (insert results))
+	         (org-babel-import-elisp-from-file tmp-file)))
 	     (org-babel-pick-name
 	      (cdr (assoc :colname-names params)) (cdr (assoc :colnames params)))
 	     (org-babel-pick-name
-	      (cdr (assoc :rowname-names params)) (cdr (assoc :rownames params))))))))
+	      (cdr (assoc :rowname-names params)) (cdr (assoc :rownames params)))))
+      )))
 
 (defun org-babel-nim-expand-nim (body params)
   "Expand a block of nim code with org-babel according to


### PR DESCRIPTION
This reverts commit efea4a765df47322932f62bde59f42f742e5dcf9.

This PR reverts https://github.com/Lompik/ob-nim/pull/5 (except the auto-indentation commit) -- checking if that fixes the CI failure seen in https://github.com/Lompik/ob-nim/runs/2720365777.