### PR TITLE
Do not try to convert results to numbers

### DIFF
--- a/ob-nim.el
+++ b/ob-nim.el
@@ -111,16 +111,16 @@ header arguments."
 	        "")))
       (when results
 	    (org-babel-reassemble-table
-	     (org-babel-result-cond (cdr (assoc :result-params params))
-	       (org-babel-read results t)
+         (org-babel-result-cond (cdr (assoc :result-params params))
+	       results
 	       (let ((tmp-file (org-babel-temp-file "c-")))
 	         (with-temp-file tmp-file (insert results))
-	         (org-babel-import-elisp-from-file tmp-file)))
+	         (org-babel-import-elisp-from-file tmp-file))
+           )
 	     (org-babel-pick-name
 	      (cdr (assoc :colname-names params)) (cdr (assoc :colnames params)))
 	     (org-babel-pick-name
-	      (cdr (assoc :rowname-names params)) (cdr (assoc :rownames params)))))
-      )))
+	      (cdr (assoc :rowname-names params)) (cdr (assoc :rownames params))))))))
 
 (defun org-babel-nim-expand-nim (body params)
   "Expand a block of nim code with org-babel according to

--- a/tests/test-ob-nim.el
+++ b/tests/test-ob-nim.el
@@ -96,6 +96,17 @@ for j in temp[\"col1\"].low..temp[\"col1\"].high:
      (goto-char 0)
      (org-babel-next-src-block)
      (expect (org-babel-execute-src-block) :to-equal '(("col1" "col2") hline ("a" 1) ("b" 2.0))))
+
+ (it "should not modify nim output
+"
+     (insert "#+begin_src nim :results output
+echo \"-0\"
+#+end_src")
+     (goto-char 0)
+     (expect (org-babel-execute-src-block) :to-equal "-0
+"))
+
  )
+
 (provide 'test-ob-nim)
 ;;; test-ob-nim.el ends here


### PR DESCRIPTION
Below is tested on Org 9.4.6-544-gc5573b

Before this commit:

    #+begin_src nim
    echo "-0"
    #+end_src
    #+RESULTS:
    : 0

After this commit:

    #+begin_src nim
    echo "-0"
    #+end_src
    #+RESULTS:
    : -0

There was a bug in `org-babel--string-to-number` which got fixed
recently in
https://code.orgmode.org/bzg/org-mode/commit/4c934424d6e45daa30d2e5a2b3217181216d4e37
. This piece of `ob-nim` code was affected because `org-babel-read`
was using `org-babel--string-to-number` internally.

Reviewing the code in `org-babel-read` and also looking at
`ob-python.el`, it looks like that function isn't required here. So
using just `results` directly.

This commit also adds a test that proves this fix.